### PR TITLE
Lazily serialize the TeX hyphenation patterns

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -178,6 +178,10 @@ impl<'a> KLPTrieIO<'a> for Exceptions {
 
 
 fn main() {
+    if Path::new("patterns").is_dir() {
+        return;
+    }
+
     let output_suffixes = vec![Patterns::suffix_out(), Exceptions::suffix_out()];
     let langs = vec![
         "af",

--- a/build.rs
+++ b/build.rs
@@ -178,7 +178,9 @@ impl<'a> KLPTrieIO<'a> for Exceptions {
 
 
 fn main() {
-    if Path::new("patterns").is_dir() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    if Path::new(&out_dir).join("pocket-resources.rs").exists() {
         return;
     }
 


### PR DESCRIPTION
It would seem that the build script unconditionally recreates the content of the `patterns` directory. Therefore, the compilation process of a crate that depends on *hyphenation* always *pauses* when it takes care of the *hyphenation* crate.