### PR TITLE
Derive `Clone` for `Standard`.

### DIFF
--- a/hyphenation_commons/src/dictionary/mod.rs
+++ b/hyphenation_commons/src/dictionary/mod.rs
@@ -19,7 +19,7 @@ pub struct Locus {
 }
 
 /// A trie mapping hyphenation patterns to their tallies.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Patterns {
     tallies : Vec<Vec<Locus>>,
     automaton : Trie
@@ -42,7 +42,7 @@ pub struct Exceptions(pub HashMap<String, Vec<usize>>);
 ///
 /// It comprises the working language, the pattern and exception sets,
 /// and the character boundaries for hyphenation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Standard {
     language : Language,
     patterns : Patterns,

--- a/hyphenation_commons/src/dictionary/trie.rs
+++ b/hyphenation_commons/src/dictionary/trie.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::slice;
 
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Trie(Map<Vec<u8>>);
 
 impl Trie {


### PR DESCRIPTION
It seems odd, that the `Standard` struct, is `Serialize` and `Deserialize`, but not `Clone`. So I add it, as well as to the structs it depends on.