### PR TITLE
Remove unused `memmap` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ hyphenation_commons = { path = "hyphenation_commons", version = "0.8.3" }
 fst = "0.4.6"
 bincode = "1.3.3"
 serde = "1.0.126"
-memmap = "0.7.0"
 
 [build-dependencies]
 hyphenation_commons = { path = "hyphenation_commons", version = "0.8.3" }


### PR DESCRIPTION
I noticed that the dependency was added in 458e62627cde0fd2dbbeae3d81d684ba14ba310a, but `memmap` is not mentioned anywhere in the codebase.

I tried removing it locally and the tests pass — plus, I can now compile `hyphenation` for WebAssembly in my demo here: https://mgeisler.github.io/textwrap/.