### PR TITLE
Enable the `embed_en-us` feature on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ nfd = ["unicode-normalization"]
 nfkc = ["unicode-normalization"]
 nfkd = ["unicode-normalization"]
 
+[package.metadata.docs.rs]
+features = ["embed_en-us"]
 
 [workspace]
 members = ["hyphenation_commons"]


### PR DESCRIPTION
As per https://docs.rs/about/metadata, this will enable the `embed_en-us` feature when documentation in generated on docs.rs. This in turn will allow people to find conditionally available methods such as `Load::from_embedded`. Note that the function will show up as if it is always available — let me know if you want me to add a note about this to its docstring.