### PR TITLE
Add try_from_code to Language

### DIFF
--- a/hyphenation_commons/src/language.rs
+++ b/hyphenation_commons/src/language.rs
@@ -28,6 +28,14 @@ macro_rules! fiant_linguae {
                     $( Language::$lang => $code, )*
                 }
             }
+
+            /// Try and construct a Language from a [BCP 47](https://tools.ietf.org/html/bcp47) tag.
+            pub fn try_from_code<T: AsRef<str>>(code: T) -> Option<Language> {
+                match code.as_ref() {
+                    $( $code => Some(Language::$lang), )*
+                    _ => None
+                }
+            }
         }
 
         impl fmt::Display for Language {


### PR DESCRIPTION
This PR adds
```rust
Language::try_from_code<S: AsRef<str>>(S) -> Option<Language>
```

I found myself needing this while using this crate, and since `Language` already has `code(&self) -> &str`, I thought this would be consistent.